### PR TITLE
feat: update Firebase emulator integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ node_modules/
 .env
 
 .DS_Store
+
+# Firebase emulator temp export files
+firebase-export-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
-FROM node:14.18.0-alpine
-RUN npm install firebase-functions@latest firebase-admin@latest --save
-RUN npm install -g firebase-tools@11.30.0
-COPY . /firebase
-RUN cd firebase/functions && npm install
-WORKDIR /firebase/
+FROM node:22-bullseye-slim
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends openjdk-11-jdk bash procps
+
+WORKDIR /firebase
+
+# renovate: datasource=github-tags depName=firebase/firebase-tools
+ARG FIREBASE_TOOLS_VERSION=14.5.1
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g firebase-tools@$FIREBASE_TOOLS_VERSION \
+    # Download jar files
+    && firebase setup:emulators:database \
+    && firebase setup:emulators:firestore \
+    && firebase setup:emulators:storage \
+    && firebase setup:emulators:ui

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+# TODO: This may need another look
+cd functions
+yarn install --frozen-lockfile
+yarn build
+cd ../
+
+# PIDs
+pid=0
+tail_pid=0
+
+# Signal handler for graceful shutdown
+graceful_shutdown() {
+  echo "[INFO] Caught termination signal. Forwarding to Firebase emulator..."
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid"
+    wait "$pid"
+  fi
+
+  if kill -0 "$tail_pid" 2>/dev/null; then
+    kill "$tail_pid"
+    wait "$tail_pid"
+  fi
+
+  echo "[INFO] Firebase shut down gracefully, export should be complete."
+  exit 0
+}
+
+# Trap SIGINT and SIGTERM for Docker shutdown
+trap graceful_shutdown SIGINT SIGTERM
+
+# Start Firebase emulator in background
+echo "[INFO] Starting Firebase emulator..."
+FIREBASE_EMULATOR_DATA_DIR=${FIREBASE_EMULATOR_DATA_DIR?FIREBASE_EMULATOR_DATA_DIR is required}
+firebase emulators:start --import="$FIREBASE_EMULATOR_DATA_DIR" --export-on-exit &
+pid="$!"
+
+
+# Keep container alive with dummy tail
+tail -f /dev/null &
+tail_pid="$!"
+
+# Wait on both Firebase and tail, exit if either ends
+wait -n "$pid" "$tail_pid"
+
+# If we got here without a signal, something ended unexpectedly
+echo "[ERROR] Firebase or keep-alive process exited unexpectedly"
+exit 1

--- a/firebase.json
+++ b/firebase.json
@@ -24,20 +24,27 @@
     ]
   },
   "emulators": {
+    "singleProjectMode": true,
     "auth": {
+      "host": "0.0.0.0",
       "port": 9099
     },
     "functions": {
+      "host": "0.0.0.0",
       "port": 5001
     },
     "database": {
+      "host": "0.0.0.0",
       "port": 9000
     },
     "hosting": {
+      "host": "0.0.0.0",
       "port": 5000
     },
     "ui": {
-      "enabled": true
+      "enabled": true,
+      "port": 4000,
+      "host": "0.0.0.0"
     }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.5.4"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "private": true
 }


### PR DESCRIPTION
- Upgrade to node 22
- Updated `.gitignore` to exclude Firebase emulator temp export files (`firebase-export-*`)
- Replaced old Dockerfile with Node 22 + OpenJDK image and pre-download Firebase emulator components (jar files)
- Introduced `docker_entrypoint.sh` to manage emulator lifecycle with graceful shutdown and data persistence
- Bind emulator services to `0.0.0.0` for container accessibility