### PR TITLE
feat(docker): add multistage build for emulator and deployment

### DIFF
--- a/.github/workflows/docker-push-dev.yml
+++ b/.github/workflows/docker-push-dev.yml
@@ -21,7 +21,7 @@ jobs:
           REPO_NAME: ghcr.io/${{ github.repository }}
         run: |
           REPO_NAME=$(echo $REPO_NAME | tr '[:upper:]' '[:lower:]')
-          TAG="0.3.1-dev"
+          TAG="0.3.2-dev"
 
           # Docker
           echo "docker_image_name=${REPO_NAME}" >> $GITHUB_OUTPUT
@@ -54,6 +54,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
+          target: emulator
           file: Dockerfile
           push: false
           load: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # NOTE: If you make any BREAKING CHANGE:
 # - Update the Docker image tag in `./.github/workflows/docker-push-dev.yml`
 # - Update the `mapswipe-backend` workflow to use the new image tag
-FROM node:20-bullseye-slim
+FROM node:20-bullseye-slim AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -18,9 +18,12 @@ WORKDIR /firebase
 ARG FIREBASE_TOOLS_VERSION=14.5.1
 
 RUN --mount=type=cache,target=/root/.npm \
-    npm install -g firebase-tools@$FIREBASE_TOOLS_VERSION \
-    # Download jar files
-    && firebase setup:emulators:database \
+    npm install -g firebase-tools@$FIREBASE_TOOLS_VERSION
+
+FROM base AS emulator
+
+# Pre-download firebase emulator tools
+RUN firebase setup:emulators:database \
     && firebase setup:emulators:firestore \
     && firebase setup:emulators:storage \
     && firebase setup:emulators:ui


### PR DESCRIPTION
## Change:
- Separate out base and simulator build using multi-stage


## NOTE:
Requires this change in mapswipe-backend
```diff
diff --git a/docker-compose.yaml b/docker-compose.yaml
index 2ef72bd0..1d2254a5 100644
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 x-firebase: &base_firebase_setup
   build:
     context: ./firebase/
+    target: emulator
   stop_grace_period: 30s
   tty: true
   entrypoint: ["./docker_entrypoint.sh"]
   ```