### PR TITLE
feat(conflation): add definitions and models for conflation

### DIFF
--- a/functions/definition/project/common.yaml
+++ b/functions/definition/project/common.yaml
@@ -40,6 +40,8 @@ FbEnumProjectType:
         value: 4
       - label: 'STREET'
         value: 7
+      - label: 'CONFLATION'
+        value: 8
 
 FbProjectReadonlyType:
   model: alias
@@ -176,7 +178,7 @@ FbMappingTaskCreateOnlyInput:
 FbMappingResult:
   model: alias
   # path: results/{projectId}/{groupId}/{userId}
-  docs: Represents a mapswipe project
+  docs: Represents a mapswipe result
   type:
     type: object
     fields:
@@ -190,6 +192,11 @@ FbMappingResult:
         type: timestamp
       startTime:
         type: timestamp
+      reference:
+        optional: true
+        type:
+          type: map
+          valueType: FbConflationReferenceEntry
       results:
         optional: true
         type:

--- a/functions/definition/project/project_types/conflation.yaml
+++ b/functions/definition/project/project_types/conflation.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/toggle-corp/typesync/refs/tags/v1.0.0/schema.local.json
+
+FbProjectConflationCreateOnlyInput:
+  model: alias
+  docs: Represents CONFLATION project fields that are valid while creating a project
+  type:
+    type: object
+    fields:
+      tileServer:
+        type: FbObjRasterTileServer
+
+FbMappingGroupConflationCreateOnlyInput:
+  model: alias
+  docs: Represents CONFLATION mapping group fields that are valid while creating a mapping group
+  type:
+    type: object
+    fields:
+      groupId:
+        type: string
+
+FbMappingTaskConflationCreateOnlyInput:
+  model: alias
+  docs: Represents CONFLATION mapping task fields that are valid while creating a task
+  type:
+    type: object
+    fields:
+      taskId:
+        type: string
+      geojson:
+        # NOTE: This is not optional
+        type:
+          type: map
+          valueType: any
+
+FbConflationReferenceEntry:
+  model: alias
+  docs: Represents the OSM reference features in CONFLATION mapping results
+  type:
+    type: object
+    fields:
+      numberIntersecting:
+        type: int
+      # NOTE: osmID, osmType, and version only to be provided when numberIntersection == 1
+      osmId:
+        type: int
+        optional: true
+      osmType:
+        type: string
+        optional: true
+      version:
+        type: int
+        optional: true

--- a/functions/definition/tutorial/project_types/conflation.yaml
+++ b/functions/definition/tutorial/project_types/conflation.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/toggle-corp/typesync/refs/tags/v1.0.0/schema.local.json
+
+FbConflationTutorial:
+  model: alias
+  type:
+    type: object
+    fields:
+      # NOTE: local path to geometry file
+      inputGeometries:
+        type: string
+        deprecated: true
+      projectType:
+        type:
+          type: literal
+          value: 8
+      tileServer:
+        type: FbObjRasterTileServer
+      zoomLevel:
+        type: int
+        deprecated: true
+
+FbConflationTutorialTaskProperties:
+  model: alias
+  type:
+    type: object
+    fields:
+      id:
+        type: int
+      screen:
+        type: int
+      reference:
+        type: int
+
+FbConflationTutorialTask:
+  model: alias
+  type:
+    type: object
+    fields:
+      taskId:
+        type: string
+      geojson: # NOTE: polygon geometry object
+        type: unknown
+      properties:
+        type: FbConflationTutorialTaskProperties
+      geometry: # NOTE: geometry as WKT
+        type: string

--- a/functions/generated/pyfirebase/pyfirebase_mapswipe/models.py
+++ b/functions/generated/pyfirebase/pyfirebase_mapswipe/models.py
@@ -16,7 +16,7 @@ class TypesyncUndefined:
     def __init__(self):
         if TypesyncUndefined._instance is not None:
             raise RuntimeError(
-                "TypesyncUndefined instances cannot be created directly. Import and use the UNDEFINED sentinel instead."
+                "TypesyncUndefined instances cannot be created directly. Import and use the UNDEFINED sentinel instead.",
             )
         TypesyncUndefined._instance = self
 
@@ -596,7 +596,8 @@ class FbObjRasterTileServer(TypesyncModel):
 
     apiKey: str | TypesyncUndefined | None = UNDEFINED
     wmtsLayerName: typing.Annotated[
-        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+        str | TypesyncUndefined | None,
+        pydantic.Field(deprecated=True),
     ] = UNDEFINED
     credits: str
     name: FbEnumRasterTileServerName
@@ -873,10 +874,12 @@ class FbScreen(TypesyncModel):
 
 class FbBaseTutorial(TypesyncModel):
     exampleImage1: typing.Annotated[
-        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+        str | TypesyncUndefined | None,
+        pydantic.Field(deprecated=True),
     ] = UNDEFINED
     exampleImage2: typing.Annotated[
-        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+        str | TypesyncUndefined | None,
+        pydantic.Field(deprecated=True),
     ] = UNDEFINED
     contributorCount: int
     informationPages: list[FbInformationPage] | TypesyncUndefined | None = UNDEFINED
@@ -1222,10 +1225,12 @@ class FbUserReadonlyType(TypesyncModel):
     created: datetime.datetime
     lastAppUse: datetime.datetime | TypesyncUndefined | None = UNDEFINED
     userName: typing.Annotated[
-        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+        str | TypesyncUndefined | None,
+        pydantic.Field(deprecated=True),
     ] = UNDEFINED
     userNameKey: typing.Annotated[
-        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+        str | TypesyncUndefined | None,
+        pydantic.Field(deprecated=True),
     ] = UNDEFINED
     username: str | TypesyncUndefined | None = UNDEFINED
     usernameKey: str | TypesyncUndefined | None = UNDEFINED

--- a/functions/generated/pyfirebase/pyfirebase_mapswipe/models.py
+++ b/functions/generated/pyfirebase/pyfirebase_mapswipe/models.py
@@ -10,11 +10,14 @@ from pydantic_core import core_schema
 
 class TypesyncUndefined:
     """Do not use this class in your code. Use the `UNDEFINED` sentinel instead."""
+
     _instance = None
 
     def __init__(self):
         if TypesyncUndefined._instance is not None:
-            raise RuntimeError("TypesyncUndefined instances cannot be created directly. Import and use the UNDEFINED sentinel instead.")
+            raise RuntimeError(
+                "TypesyncUndefined instances cannot be created directly. Import and use the UNDEFINED sentinel instead."
+            )
         TypesyncUndefined._instance = self
 
     @classmethod
@@ -27,8 +30,10 @@ class TypesyncUndefined:
             raise ValueError("Undefined field type is not valid")
         return value
 
+
 UNDEFINED = TypesyncUndefined()
 """A sentinel value that can be used to indicate that a value should be undefined. During serialization all values that are marked as undefined will be removed. The difference between `UNDEFINED` and `None` is that values that are set to `None` will serialize to explicit null."""
+
 
 class TypesyncModel(pydantic.BaseModel):
     def model_dump(self, **kwargs) -> dict[str, typing.Any]:
@@ -37,19 +42,32 @@ class TypesyncModel(pydantic.BaseModel):
             if isinstance(field_value, pydantic.BaseModel):
                 processed[field_name] = field_value.model_dump(**kwargs)
             elif isinstance(field_value, list):
-                processed[field_name] = [item.model_dump(**kwargs) if isinstance(item, pydantic.BaseModel) else item for item in field_value]
+                processed[field_name] = [
+                    item.model_dump(**kwargs)
+                    if isinstance(item, pydantic.BaseModel)
+                    else item
+                    for item in field_value
+                ]
             elif isinstance(field_value, dict):
-                processed[field_name] = {key: value.model_dump(**kwargs) if isinstance(value, pydantic.BaseModel) else value for key, value in field_value.items()}
+                processed[field_name] = {
+                    key: value.model_dump(**kwargs)
+                    if isinstance(value, pydantic.BaseModel)
+                    else value
+                    for key, value in field_value.items()
+                }
             elif field_value is UNDEFINED:
                 continue
             else:
                 processed[field_name] = field_value
         return processed
 
+
 # Model Definitions
+
 
 class FbAnnouncement(TypesyncModel):
     """Represents app announcements for the contributors."""
+
     url: str
     text: str
 
@@ -61,8 +79,10 @@ class FbAnnouncement(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbOrganisation(TypesyncModel):
     """Represents the requesting organisation."""
+
     name: str
     description: str | TypesyncUndefined | None = UNDEFINED
     nameKey: typing.Annotated[str, pydantic.Field(deprecated=True)]
@@ -81,8 +101,10 @@ class FbOrganisation(TypesyncModel):
             raise ValueError("'abbreviation' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbEnumProjectStatus(enum.Enum):
     """Represents project status"""
+
     ACTIVE = "active"
     INACTIVE = "inactive"
     PRIVATE_INACTIVE = "private_inactive"
@@ -90,8 +112,10 @@ class FbEnumProjectStatus(enum.Enum):
     FINISHED = "finished"
     PRIVATE_FINISHED = "private_finished"
 
+
 class FbEnumProjectType(enum.Enum):
     """Represents project type"""
+
     FIND = 1
     VALIDATE = 2
     VALIDATE_IMAGE = 10
@@ -100,8 +124,10 @@ class FbEnumProjectType(enum.Enum):
     STREET = 7
     CONFLATION = 8
 
+
 class FbProjectReadonlyType(TypesyncModel):
     """Represents project fields that cannot be updated from backend"""
+
     resultCount: int
 
     class Config:
@@ -112,8 +138,10 @@ class FbProjectReadonlyType(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbProjectUpdateStatsInput(TypesyncModel):
     """Represents project fields that are valid while updating a project stats"""
+
     contributorCount: int
     progress: int
 
@@ -125,8 +153,10 @@ class FbProjectUpdateStatsInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbProjectUpdateInput(TypesyncModel):
     """Represents project fields that are valid while updating a project"""
+
     image: str | TypesyncUndefined | None = UNDEFINED
     isFeatured: bool
     lookFor: str | TypesyncUndefined | None = UNDEFINED
@@ -167,8 +197,10 @@ class FbProjectUpdateInput(TypesyncModel):
             raise ValueError("'maxTasksPerUser' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbProjectCreateOnlyInput(TypesyncModel):
     """Represents project fields that are valid while creating a project"""
+
     created: datetime.datetime
     createdBy: str
     groupMaxSize: int
@@ -186,8 +218,10 @@ class FbProjectCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingGroupReadonlyType(TypesyncModel):
     """Represents mapping group fields that cannot be updated from backend"""
+
     finishedCount: int
     progress: int
 
@@ -199,8 +233,10 @@ class FbMappingGroupReadonlyType(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingGroupCreateOnlyInput(TypesyncModel):
     """Represents mapping group fields that are valid while creating a mapping group"""
+
     projectId: str
     numberOfTasks: int
     requiredCount: int
@@ -213,8 +249,10 @@ class FbMappingGroupCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingTaskCreateOnlyInput(TypesyncModel):
     """Represents mapping task fields that are valid while creating a task"""
+
     projectId: str
 
     class Config:
@@ -225,8 +263,10 @@ class FbMappingTaskCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbBaseObjCustomSubOption(TypesyncModel):
     """Represents a custom sub-option"""
+
     value: int
     description: str
 
@@ -238,8 +278,10 @@ class FbBaseObjCustomSubOption(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbObjCustomOption(TypesyncModel):
     """Represents a custom option"""
+
     value: int
     title: str
     description: str
@@ -257,8 +299,10 @@ class FbObjCustomOption(TypesyncModel):
             raise ValueError("'subOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbMappingTaskCompareCreateOnlyInput(TypesyncModel):
     """Represents COMPARE mapping task fields that are valid while creating a task"""
+
     groupId: str
     taskId: str
     taskX: int | TypesyncUndefined | None = UNDEFINED
@@ -282,12 +326,15 @@ class FbMappingTaskCompareCreateOnlyInput(TypesyncModel):
             raise ValueError("'urlB' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbEnumOverlayTileServerType(enum.Enum):
     RASTER = "raster"
     VECTOR = "vector"
 
+
 class FbMappingGroupConflationCreateOnlyInput(TypesyncModel):
     """Represents CONFLATION mapping group fields that are valid while creating a mapping group"""
+
     groupId: str
 
     class Config:
@@ -298,8 +345,10 @@ class FbMappingGroupConflationCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingTaskConflationCreateOnlyInput(TypesyncModel):
     """Represents CONFLATION mapping task fields that are valid while creating a task"""
+
     taskId: str
     geojson: dict[str, typing.Any]
 
@@ -311,8 +360,10 @@ class FbMappingTaskConflationCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbConflationReferenceEntry(TypesyncModel):
     """Represents the OSM reference features in CONFLATION mapping results"""
+
     numberIntersecting: int
     osmId: int | TypesyncUndefined | None = UNDEFINED
     osmType: str | TypesyncUndefined | None = UNDEFINED
@@ -332,13 +383,17 @@ class FbConflationReferenceEntry(TypesyncModel):
             raise ValueError("'version' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbMappingResult(TypesyncModel):
     """Represents a mapswipe result"""
+
     appVersion: str
     clientType: str | TypesyncUndefined | None = UNDEFINED
     endTime: datetime.datetime
     startTime: datetime.datetime
-    reference: dict[str, FbConflationReferenceEntry] | TypesyncUndefined | None = UNDEFINED
+    reference: dict[str, FbConflationReferenceEntry] | TypesyncUndefined | None = (
+        UNDEFINED
+    )
     results: dict[str, int] | TypesyncUndefined | None = UNDEFINED
     usergroups: dict[str, bool] | TypesyncUndefined | None = UNDEFINED
 
@@ -358,8 +413,10 @@ class FbMappingResult(TypesyncModel):
             raise ValueError("'usergroups' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbProjectStreetCreateOnlyInput(TypesyncModel):
     """Represents STREET project fields that are valid while creating a project"""
+
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
     numberOfGroups: int
 
@@ -373,8 +430,10 @@ class FbProjectStreetCreateOnlyInput(TypesyncModel):
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbMappingGroupStreetCreateOnlyInput(TypesyncModel):
     """Represents STREET mapping group fields that are valid while creating a mapping group"""
+
     groupId: str
 
     class Config:
@@ -385,8 +444,10 @@ class FbMappingGroupStreetCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingTaskStreetCreateOnlyInput(TypesyncModel):
     """Represents STREET mapping task fields that are valid while creating a task"""
+
     taskId: int
     groupId: str
 
@@ -398,8 +459,10 @@ class FbMappingTaskStreetCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingGroupTileMapServiceCreateOnlyInput(TypesyncModel):
     """Represents TILE_MAP_SERVICE mapping group fields that are valid while creating a mapping group"""
+
     groupId: str
     xMax: int
     xMin: int
@@ -414,13 +477,16 @@ class FbMappingGroupTileMapServiceCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbEnumValidateInputType(enum.Enum):
     AOI_FILE = "aoi_file"
     LINK = "link"
     TMID = "TMId"
 
+
 class FbMappingGroupValidateCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE mapping group fields that are valid while creating a mapping group"""
+
     groupId: str
 
     class Config:
@@ -431,8 +497,10 @@ class FbMappingGroupValidateCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingTaskValidateCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE mapping task fields that are valid while creating a task"""
+
     taskId: str
     geojson: dict[str, typing.Any]
 
@@ -444,12 +512,15 @@ class FbMappingTaskValidateCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbEnumValidateImageInputType(enum.Enum):
     DIRECT_IMAGES = "direct_images"
     DATASET_FILE = "dataset_file"
 
+
 class FbProjectValidateImageCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE_IMAGE project fields that are valid while creating a project"""
+
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
 
     class Config:
@@ -462,8 +533,10 @@ class FbProjectValidateImageCreateOnlyInput(TypesyncModel):
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbMappingGroupValidateImageCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE_IMAGE mapping group fields that are valid while creating a mapping group"""
+
     groupId: str
 
     class Config:
@@ -474,8 +547,10 @@ class FbMappingGroupValidateImageCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbMappingTaskValidateImageCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE_IMAGE mapping task fields that are valid while creating a task"""
+
     taskId: str
     url: str
     fileName: str
@@ -503,8 +578,10 @@ class FbMappingTaskValidateImageCreateOnlyInput(TypesyncModel):
             raise ValueError("'segmentation' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbEnumRasterTileServerName(enum.Enum):
     """Represents supported raster tile server"""
+
     CUSTOM = "custom"
     BING = "bing"
     MAPBOX = "mapbox"
@@ -513,10 +590,14 @@ class FbEnumRasterTileServerName(enum.Enum):
     ESRI = "esri"
     ESRI_BETA = "esriBeta"
 
+
 class FbObjRasterTileServer(TypesyncModel):
     """Represents a raster tile server configuration"""
+
     apiKey: str | TypesyncUndefined | None = UNDEFINED
-    wmtsLayerName: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
+    wmtsLayerName: typing.Annotated[
+        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+    ] = UNDEFINED
     credits: str
     name: FbEnumRasterTileServerName
     url: str
@@ -533,8 +614,10 @@ class FbObjRasterTileServer(TypesyncModel):
             raise ValueError("'wmtsLayerName' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbProjectCompareCreateOnlyInput(TypesyncModel):
     """Represents COMPARE project fields that are valid while creating a project"""
+
     zoomLevel: int
     tileServer: FbObjRasterTileServer
     tileServerB: FbObjRasterTileServer
@@ -547,8 +630,10 @@ class FbProjectCompareCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbProjectConflationCreateOnlyInput(TypesyncModel):
     """Represents CONFLATION project fields that are valid while creating a project"""
+
     tileServer: FbObjRasterTileServer
 
     class Config:
@@ -559,8 +644,10 @@ class FbProjectConflationCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbProjectFindCreateOnlyInput(TypesyncModel):
     """Represents FIND project fields that are valid while creating a project"""
+
     zoomLevel: int
     tileServer: FbObjRasterTileServer
 
@@ -572,8 +659,10 @@ class FbProjectFindCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbProjectValidateCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE project fields that are valid while creating a project"""
+
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
     tileServer: FbObjRasterTileServer
     inputType: FbEnumValidateInputType
@@ -594,8 +683,10 @@ class FbProjectValidateCreateOnlyInput(TypesyncModel):
             raise ValueError("'TMId' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbObjRasterTileServerOverlay(TypesyncModel):
     """Represents an overlay layer for raster layer"""
+
     tileServer: FbObjRasterTileServer
     opacity: float
 
@@ -607,15 +698,19 @@ class FbObjRasterTileServerOverlay(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbEnumVectorTileServerName(enum.Enum):
     """Represents supported vector tile server"""
+
     CUSTOM = "custom"
     OPEN_STREET_MAP = "openStreetMap"
     OPEN_FREE_MAP = "openFreeMap"
     VERSATILES = "versatiles"
 
+
 class FbObjVectorTileServer(TypesyncModel):
     """Represents a vector tile server configuration"""
+
     credits: str
     name: FbEnumVectorTileServerName
     sourceLayer: str
@@ -631,8 +726,10 @@ class FbObjVectorTileServer(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbObjVectorTileServerOverlay(TypesyncModel):
     """Represents an overlay layer for vector layer"""
+
     tileServer: FbObjVectorTileServer
     fillColor: str
     fillOpacity: float
@@ -652,8 +749,10 @@ class FbObjVectorTileServerOverlay(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbObjUnifiedOverlayTileServer(TypesyncModel):
     """Represents an overlay layer"""
+
     type: FbEnumOverlayTileServerType
     raster: FbObjRasterTileServerOverlay | TypesyncUndefined | None = UNDEFINED
     vector: FbObjVectorTileServerOverlay | TypesyncUndefined | None = UNDEFINED
@@ -670,8 +769,10 @@ class FbObjUnifiedOverlayTileServer(TypesyncModel):
             raise ValueError("'vector' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbProjectCompletenessCreateOnlyInput(TypesyncModel):
     """Represents COMPLETNESS project fields that are valid while creating a project"""
+
     zoomLevel: int
     tileServer: FbObjRasterTileServer
     tileServerB: FbObjRasterTileServer
@@ -685,8 +786,10 @@ class FbProjectCompletenessCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbTeam(TypesyncModel):
     """Represents a team to limit project visibility."""
+
     teamName: str
     teamToken: str
     isArchived: bool
@@ -699,9 +802,11 @@ class FbTeam(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbEnumInformationPageBlockType(enum.Enum):
     TEXT = "text"
     IMAGE = "image"
+
 
 class FbInformationPageBlock(TypesyncModel):
     blockNumber: int
@@ -721,6 +826,7 @@ class FbInformationPageBlock(TypesyncModel):
             raise ValueError("'image' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbInformationPage(TypesyncModel):
     pageNumber: int
     title: str
@@ -736,6 +842,7 @@ class FbInformationPage(TypesyncModel):
             raise ValueError("'blocks' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbScreenBlock(TypesyncModel):
     title: str
     description: str
@@ -748,6 +855,7 @@ class FbScreenBlock(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+
 
 class FbScreen(TypesyncModel):
     hint: FbScreenBlock
@@ -762,9 +870,14 @@ class FbScreen(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbBaseTutorial(TypesyncModel):
-    exampleImage1: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
-    exampleImage2: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
+    exampleImage1: typing.Annotated[
+        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+    ] = UNDEFINED
+    exampleImage2: typing.Annotated[
+        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+    ] = UNDEFINED
     contributorCount: int
     informationPages: list[FbInformationPage] | TypesyncUndefined | None = UNDEFINED
     lookFor: str | TypesyncUndefined | None = UNDEFINED
@@ -795,6 +908,7 @@ class FbBaseTutorial(TypesyncModel):
             raise ValueError("'screens' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbBaseTutorialGroup(TypesyncModel):
     finishedCount: int
     groupId: int
@@ -811,6 +925,7 @@ class FbBaseTutorialGroup(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbCompareTutorial(TypesyncModel):
     projectType: typing.Literal[3]
     tileServer: FbObjRasterTileServer
@@ -825,6 +940,7 @@ class FbCompareTutorial(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbCompareTutorialTask(TypesyncModel):
     url: str
     urlB: str
@@ -836,6 +952,7 @@ class FbCompareTutorialTask(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+
 
 class FbCompletenessTutorial(TypesyncModel):
     projectType: typing.Literal[4]
@@ -852,6 +969,7 @@ class FbCompletenessTutorial(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbCompletenessTutorialTask(TypesyncModel):
     url: str
     urlB: str
@@ -863,6 +981,7 @@ class FbCompletenessTutorialTask(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+
 
 class FbConflationTutorial(TypesyncModel):
     inputGeometries: typing.Annotated[str, pydantic.Field(deprecated=True)]
@@ -878,6 +997,7 @@ class FbConflationTutorial(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbConflationTutorialTaskProperties(TypesyncModel):
     id: int
     screen: int
@@ -890,6 +1010,7 @@ class FbConflationTutorialTaskProperties(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+
 
 class FbConflationTutorialTask(TypesyncModel):
     taskId: str
@@ -905,6 +1026,7 @@ class FbConflationTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbFindTutorial(TypesyncModel):
     projectType: typing.Literal[1]
     tileServer: FbObjRasterTileServer
@@ -918,6 +1040,7 @@ class FbFindTutorial(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbFindTutorialTask(TypesyncModel):
     url: str
 
@@ -928,6 +1051,7 @@ class FbFindTutorialTask(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+
 
 class FbStreetTutorial(TypesyncModel):
     projectType: typing.Literal[7]
@@ -942,6 +1066,7 @@ class FbStreetTutorial(TypesyncModel):
         if name == "customOptions" and value is None:
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
+
 
 class FbStreetTutorialTask(TypesyncModel):
     projectId: str
@@ -959,6 +1084,7 @@ class FbStreetTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbTileMapServiceTutorialGroup(TypesyncModel):
     xMax: int
     xMin: int
@@ -972,6 +1098,7 @@ class FbTileMapServiceTutorialGroup(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+
 
 class FbTileMapServiceTutorialTask(TypesyncModel):
     geometry: str
@@ -992,6 +1119,7 @@ class FbTileMapServiceTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbValidateTutorial(TypesyncModel):
     inputGeometries: typing.Annotated[str, pydantic.Field(deprecated=True)]
     projectType: typing.Literal[2]
@@ -1009,6 +1137,7 @@ class FbValidateTutorial(TypesyncModel):
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbValidateTutorialTaskProperties(TypesyncModel):
     id: int
     screen: int
@@ -1021,6 +1150,7 @@ class FbValidateTutorialTaskProperties(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+
 
 class FbValidateTutorialTask(TypesyncModel):
     taskId: str
@@ -1036,6 +1166,7 @@ class FbValidateTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbValidateImageTutorial(TypesyncModel):
     projectType: typing.Literal[10]
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
@@ -1049,6 +1180,7 @@ class FbValidateImageTutorial(TypesyncModel):
         if name == "customOptions" and value is None:
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
+
 
 class FbValidateImageTutorialTask(TypesyncModel):
     groupId: int
@@ -1083,12 +1215,18 @@ class FbValidateImageTutorialTask(TypesyncModel):
             raise ValueError("'segmentation' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbUserReadonlyType(TypesyncModel):
     """Represents user fields that cannot be updated from backend"""
+
     created: datetime.datetime
     lastAppUse: datetime.datetime | TypesyncUndefined | None = UNDEFINED
-    userName: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
-    userNameKey: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
+    userName: typing.Annotated[
+        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+    ] = UNDEFINED
+    userNameKey: typing.Annotated[
+        str | TypesyncUndefined | None, pydantic.Field(deprecated=True)
+    ] = UNDEFINED
     username: str | TypesyncUndefined | None = UNDEFINED
     usernameKey: str | TypesyncUndefined | None = UNDEFINED
     accessibility: bool | TypesyncUndefined | None = UNDEFINED
@@ -1128,8 +1266,10 @@ class FbUserReadonlyType(TypesyncModel):
             raise ValueError("'projectContributionCount' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbUserUpdateInput(TypesyncModel):
     """Represents a user"""
+
     teamId: str | TypesyncUndefined | None = UNDEFINED
 
     class Config:
@@ -1142,8 +1282,10 @@ class FbUserUpdateInput(TypesyncModel):
             raise ValueError("'teamId' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbUserContribution(TypesyncModel):
     """Represents a user contribution"""
+
     endTime: datetime.datetime
     startTime: datetime.datetime
     timestamp: datetime.datetime
@@ -1156,12 +1298,15 @@ class FbUserContribution(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbEnumUserGroupMembershipAction(enum.Enum):
     JOIN = "join"
     LEAVE = "leave"
 
+
 class FbUserGroupReadOnlyType(TypesyncModel):
     """Represents a usergroup"""
+
     users: dict[str, typing.Any] | TypesyncUndefined | None = UNDEFINED
 
     class Config:
@@ -1174,8 +1319,10 @@ class FbUserGroupReadOnlyType(TypesyncModel):
             raise ValueError("'users' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbUserGroupCreateOnlyInput(TypesyncModel):
     """Represents a usergroup"""
+
     createdAt: int
     createdBy: str
 
@@ -1187,8 +1334,10 @@ class FbUserGroupCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbUserGroupUpdateInput(TypesyncModel):
     """Represents a usergroup"""
+
     description: str
     name: str
     nameKey: typing.Annotated[str, pydantic.Field(deprecated=True)]
@@ -1207,8 +1356,10 @@ class FbUserGroupUpdateInput(TypesyncModel):
             raise ValueError("'archivedBy' field cannot be set to None")
         super().__setattr__(name, value)
 
+
 class FbUserGroupObsolete(TypesyncModel):
     """Represents a usergroup"""
+
     name: str
     description: str
 
@@ -1220,8 +1371,10 @@ class FbUserGroupObsolete(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbUserGroupMembership(TypesyncModel):
     """Represents a user contribution"""
+
     action: FbEnumUserGroupMembershipAction
     timestamp: int
     userGroupId: str
@@ -1235,8 +1388,10 @@ class FbUserGroupMembership(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+
 class FbBackendWait(TypesyncModel):
     """Represents if to wait for firebase."""
+
     ok: bool
     timestamp: datetime.datetime
 
@@ -1247,4 +1402,3 @@ class FbBackendWait(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
-

--- a/functions/generated/pyfirebase/pyfirebase_mapswipe/models.py
+++ b/functions/generated/pyfirebase/pyfirebase_mapswipe/models.py
@@ -10,14 +10,11 @@ from pydantic_core import core_schema
 
 class TypesyncUndefined:
     """Do not use this class in your code. Use the `UNDEFINED` sentinel instead."""
-
     _instance = None
 
     def __init__(self):
         if TypesyncUndefined._instance is not None:
-            raise RuntimeError(
-                "TypesyncUndefined instances cannot be created directly. Import and use the UNDEFINED sentinel instead.",
-            )
+            raise RuntimeError("TypesyncUndefined instances cannot be created directly. Import and use the UNDEFINED sentinel instead.")
         TypesyncUndefined._instance = self
 
     @classmethod
@@ -30,10 +27,8 @@ class TypesyncUndefined:
             raise ValueError("Undefined field type is not valid")
         return value
 
-
 UNDEFINED = TypesyncUndefined()
 """A sentinel value that can be used to indicate that a value should be undefined. During serialization all values that are marked as undefined will be removed. The difference between `UNDEFINED` and `None` is that values that are set to `None` will serialize to explicit null."""
-
 
 class TypesyncModel(pydantic.BaseModel):
     def model_dump(self, **kwargs) -> dict[str, typing.Any]:
@@ -42,32 +37,19 @@ class TypesyncModel(pydantic.BaseModel):
             if isinstance(field_value, pydantic.BaseModel):
                 processed[field_name] = field_value.model_dump(**kwargs)
             elif isinstance(field_value, list):
-                processed[field_name] = [
-                    item.model_dump(**kwargs)
-                    if isinstance(item, pydantic.BaseModel)
-                    else item
-                    for item in field_value
-                ]
+                processed[field_name] = [item.model_dump(**kwargs) if isinstance(item, pydantic.BaseModel) else item for item in field_value]
             elif isinstance(field_value, dict):
-                processed[field_name] = {
-                    key: value.model_dump(**kwargs)
-                    if isinstance(value, pydantic.BaseModel)
-                    else value
-                    for key, value in field_value.items()
-                }
+                processed[field_name] = {key: value.model_dump(**kwargs) if isinstance(value, pydantic.BaseModel) else value for key, value in field_value.items()}
             elif field_value is UNDEFINED:
                 continue
             else:
                 processed[field_name] = field_value
         return processed
 
-
 # Model Definitions
-
 
 class FbAnnouncement(TypesyncModel):
     """Represents app announcements for the contributors."""
-
     url: str
     text: str
 
@@ -79,10 +61,8 @@ class FbAnnouncement(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbOrganisation(TypesyncModel):
     """Represents the requesting organisation."""
-
     name: str
     description: str | TypesyncUndefined | None = UNDEFINED
     nameKey: typing.Annotated[str, pydantic.Field(deprecated=True)]
@@ -101,10 +81,8 @@ class FbOrganisation(TypesyncModel):
             raise ValueError("'abbreviation' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbEnumProjectStatus(enum.Enum):
     """Represents project status"""
-
     ACTIVE = "active"
     INACTIVE = "inactive"
     PRIVATE_INACTIVE = "private_inactive"
@@ -112,21 +90,18 @@ class FbEnumProjectStatus(enum.Enum):
     FINISHED = "finished"
     PRIVATE_FINISHED = "private_finished"
 
-
 class FbEnumProjectType(enum.Enum):
     """Represents project type"""
-
     FIND = 1
     VALIDATE = 2
     VALIDATE_IMAGE = 10
     COMPARE = 3
     COMPLETENESS = 4
     STREET = 7
-
+    CONFLATION = 8
 
 class FbProjectReadonlyType(TypesyncModel):
     """Represents project fields that cannot be updated from backend"""
-
     resultCount: int
 
     class Config:
@@ -137,10 +112,8 @@ class FbProjectReadonlyType(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbProjectUpdateStatsInput(TypesyncModel):
     """Represents project fields that are valid while updating a project stats"""
-
     contributorCount: int
     progress: int
 
@@ -152,10 +125,8 @@ class FbProjectUpdateStatsInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbProjectUpdateInput(TypesyncModel):
     """Represents project fields that are valid while updating a project"""
-
     image: str | TypesyncUndefined | None = UNDEFINED
     isFeatured: bool
     lookFor: str | TypesyncUndefined | None = UNDEFINED
@@ -196,10 +167,8 @@ class FbProjectUpdateInput(TypesyncModel):
             raise ValueError("'maxTasksPerUser' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbProjectCreateOnlyInput(TypesyncModel):
     """Represents project fields that are valid while creating a project"""
-
     created: datetime.datetime
     createdBy: str
     groupMaxSize: int
@@ -217,10 +186,8 @@ class FbProjectCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbMappingGroupReadonlyType(TypesyncModel):
     """Represents mapping group fields that cannot be updated from backend"""
-
     finishedCount: int
     progress: int
 
@@ -232,10 +199,8 @@ class FbMappingGroupReadonlyType(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbMappingGroupCreateOnlyInput(TypesyncModel):
     """Represents mapping group fields that are valid while creating a mapping group"""
-
     projectId: str
     numberOfTasks: int
     requiredCount: int
@@ -248,10 +213,8 @@ class FbMappingGroupCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbMappingTaskCreateOnlyInput(TypesyncModel):
     """Represents mapping task fields that are valid while creating a task"""
-
     projectId: str
 
     class Config:
@@ -262,35 +225,8 @@ class FbMappingTaskCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
-class FbMappingResult(TypesyncModel):
-    """Represents a mapswipe project"""
-
-    appVersion: str
-    clientType: str | TypesyncUndefined | None = UNDEFINED
-    endTime: datetime.datetime
-    startTime: datetime.datetime
-    results: dict[str, int] | TypesyncUndefined | None = UNDEFINED
-    usergroups: dict[str, bool] | TypesyncUndefined | None = UNDEFINED
-
-    class Config:
-        use_enum_values = False
-        extra = "forbid"
-
-    @typing.override
-    def __setattr__(self, name: str, value: typing.Any) -> None:
-        if name == "clientType" and value is None:
-            raise ValueError("'clientType' field cannot be set to None")
-        if name == "results" and value is None:
-            raise ValueError("'results' field cannot be set to None")
-        if name == "usergroups" and value is None:
-            raise ValueError("'usergroups' field cannot be set to None")
-        super().__setattr__(name, value)
-
-
 class FbBaseObjCustomSubOption(TypesyncModel):
     """Represents a custom sub-option"""
-
     value: int
     description: str
 
@@ -302,10 +238,8 @@ class FbBaseObjCustomSubOption(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbObjCustomOption(TypesyncModel):
     """Represents a custom option"""
-
     value: int
     title: str
     description: str
@@ -323,10 +257,8 @@ class FbObjCustomOption(TypesyncModel):
             raise ValueError("'subOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbMappingTaskCompareCreateOnlyInput(TypesyncModel):
     """Represents COMPARE mapping task fields that are valid while creating a task"""
-
     groupId: str
     taskId: str
     taskX: int | TypesyncUndefined | None = UNDEFINED
@@ -350,15 +282,84 @@ class FbMappingTaskCompareCreateOnlyInput(TypesyncModel):
             raise ValueError("'urlB' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbEnumOverlayTileServerType(enum.Enum):
     RASTER = "raster"
     VECTOR = "vector"
 
+class FbMappingGroupConflationCreateOnlyInput(TypesyncModel):
+    """Represents CONFLATION mapping group fields that are valid while creating a mapping group"""
+    groupId: str
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        super().__setattr__(name, value)
+
+class FbMappingTaskConflationCreateOnlyInput(TypesyncModel):
+    """Represents CONFLATION mapping task fields that are valid while creating a task"""
+    taskId: str
+    geojson: dict[str, typing.Any]
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        super().__setattr__(name, value)
+
+class FbConflationReferenceEntry(TypesyncModel):
+    """Represents the OSM reference features in CONFLATION mapping results"""
+    numberIntersecting: int
+    osmId: int | TypesyncUndefined | None = UNDEFINED
+    osmType: str | TypesyncUndefined | None = UNDEFINED
+    version: int | TypesyncUndefined | None = UNDEFINED
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        if name == "osmId" and value is None:
+            raise ValueError("'osmId' field cannot be set to None")
+        if name == "osmType" and value is None:
+            raise ValueError("'osmType' field cannot be set to None")
+        if name == "version" and value is None:
+            raise ValueError("'version' field cannot be set to None")
+        super().__setattr__(name, value)
+
+class FbMappingResult(TypesyncModel):
+    """Represents a mapswipe result"""
+    appVersion: str
+    clientType: str | TypesyncUndefined | None = UNDEFINED
+    endTime: datetime.datetime
+    startTime: datetime.datetime
+    reference: dict[str, FbConflationReferenceEntry] | TypesyncUndefined | None = UNDEFINED
+    results: dict[str, int] | TypesyncUndefined | None = UNDEFINED
+    usergroups: dict[str, bool] | TypesyncUndefined | None = UNDEFINED
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        if name == "clientType" and value is None:
+            raise ValueError("'clientType' field cannot be set to None")
+        if name == "reference" and value is None:
+            raise ValueError("'reference' field cannot be set to None")
+        if name == "results" and value is None:
+            raise ValueError("'results' field cannot be set to None")
+        if name == "usergroups" and value is None:
+            raise ValueError("'usergroups' field cannot be set to None")
+        super().__setattr__(name, value)
 
 class FbProjectStreetCreateOnlyInput(TypesyncModel):
     """Represents STREET project fields that are valid while creating a project"""
-
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
     numberOfGroups: int
 
@@ -372,10 +373,8 @@ class FbProjectStreetCreateOnlyInput(TypesyncModel):
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbMappingGroupStreetCreateOnlyInput(TypesyncModel):
     """Represents STREET mapping group fields that are valid while creating a mapping group"""
-
     groupId: str
 
     class Config:
@@ -386,10 +385,8 @@ class FbMappingGroupStreetCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbMappingTaskStreetCreateOnlyInput(TypesyncModel):
     """Represents STREET mapping task fields that are valid while creating a task"""
-
     taskId: int
     groupId: str
 
@@ -401,10 +398,8 @@ class FbMappingTaskStreetCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbMappingGroupTileMapServiceCreateOnlyInput(TypesyncModel):
     """Represents TILE_MAP_SERVICE mapping group fields that are valid while creating a mapping group"""
-
     groupId: str
     xMax: int
     xMin: int
@@ -419,16 +414,13 @@ class FbMappingGroupTileMapServiceCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbEnumValidateInputType(enum.Enum):
     AOI_FILE = "aoi_file"
     LINK = "link"
     TMID = "TMId"
 
-
 class FbMappingGroupValidateCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE mapping group fields that are valid while creating a mapping group"""
-
     groupId: str
 
     class Config:
@@ -439,10 +431,8 @@ class FbMappingGroupValidateCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbMappingTaskValidateCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE mapping task fields that are valid while creating a task"""
-
     taskId: str
     geojson: dict[str, typing.Any]
 
@@ -454,15 +444,12 @@ class FbMappingTaskValidateCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbEnumValidateImageInputType(enum.Enum):
     DIRECT_IMAGES = "direct_images"
     DATASET_FILE = "dataset_file"
 
-
 class FbProjectValidateImageCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE_IMAGE project fields that are valid while creating a project"""
-
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
 
     class Config:
@@ -475,10 +462,8 @@ class FbProjectValidateImageCreateOnlyInput(TypesyncModel):
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbMappingGroupValidateImageCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE_IMAGE mapping group fields that are valid while creating a mapping group"""
-
     groupId: str
 
     class Config:
@@ -489,10 +474,8 @@ class FbMappingGroupValidateImageCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbMappingTaskValidateImageCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE_IMAGE mapping task fields that are valid while creating a task"""
-
     taskId: str
     url: str
     fileName: str
@@ -520,10 +503,8 @@ class FbMappingTaskValidateImageCreateOnlyInput(TypesyncModel):
             raise ValueError("'segmentation' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbEnumRasterTileServerName(enum.Enum):
     """Represents supported raster tile server"""
-
     CUSTOM = "custom"
     BING = "bing"
     MAPBOX = "mapbox"
@@ -532,15 +513,10 @@ class FbEnumRasterTileServerName(enum.Enum):
     ESRI = "esri"
     ESRI_BETA = "esriBeta"
 
-
 class FbObjRasterTileServer(TypesyncModel):
     """Represents a raster tile server configuration"""
-
     apiKey: str | TypesyncUndefined | None = UNDEFINED
-    wmtsLayerName: typing.Annotated[
-        str | TypesyncUndefined | None,
-        pydantic.Field(deprecated=True),
-    ] = UNDEFINED
+    wmtsLayerName: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
     credits: str
     name: FbEnumRasterTileServerName
     url: str
@@ -557,10 +533,8 @@ class FbObjRasterTileServer(TypesyncModel):
             raise ValueError("'wmtsLayerName' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbProjectCompareCreateOnlyInput(TypesyncModel):
     """Represents COMPARE project fields that are valid while creating a project"""
-
     zoomLevel: int
     tileServer: FbObjRasterTileServer
     tileServerB: FbObjRasterTileServer
@@ -573,10 +547,20 @@ class FbProjectCompareCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+class FbProjectConflationCreateOnlyInput(TypesyncModel):
+    """Represents CONFLATION project fields that are valid while creating a project"""
+    tileServer: FbObjRasterTileServer
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        super().__setattr__(name, value)
 
 class FbProjectFindCreateOnlyInput(TypesyncModel):
     """Represents FIND project fields that are valid while creating a project"""
-
     zoomLevel: int
     tileServer: FbObjRasterTileServer
 
@@ -588,10 +572,8 @@ class FbProjectFindCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbProjectValidateCreateOnlyInput(TypesyncModel):
     """Represents VALIDATE project fields that are valid while creating a project"""
-
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
     tileServer: FbObjRasterTileServer
     inputType: FbEnumValidateInputType
@@ -612,10 +594,8 @@ class FbProjectValidateCreateOnlyInput(TypesyncModel):
             raise ValueError("'TMId' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbObjRasterTileServerOverlay(TypesyncModel):
     """Represents an overlay layer for raster layer"""
-
     tileServer: FbObjRasterTileServer
     opacity: float
 
@@ -627,19 +607,15 @@ class FbObjRasterTileServerOverlay(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbEnumVectorTileServerName(enum.Enum):
     """Represents supported vector tile server"""
-
     CUSTOM = "custom"
     OPEN_STREET_MAP = "openStreetMap"
     OPEN_FREE_MAP = "openFreeMap"
     VERSATILES = "versatiles"
 
-
 class FbObjVectorTileServer(TypesyncModel):
     """Represents a vector tile server configuration"""
-
     credits: str
     name: FbEnumVectorTileServerName
     sourceLayer: str
@@ -655,10 +631,8 @@ class FbObjVectorTileServer(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbObjVectorTileServerOverlay(TypesyncModel):
     """Represents an overlay layer for vector layer"""
-
     tileServer: FbObjVectorTileServer
     fillColor: str
     fillOpacity: float
@@ -678,10 +652,8 @@ class FbObjVectorTileServerOverlay(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbObjUnifiedOverlayTileServer(TypesyncModel):
     """Represents an overlay layer"""
-
     type: FbEnumOverlayTileServerType
     raster: FbObjRasterTileServerOverlay | TypesyncUndefined | None = UNDEFINED
     vector: FbObjVectorTileServerOverlay | TypesyncUndefined | None = UNDEFINED
@@ -698,10 +670,8 @@ class FbObjUnifiedOverlayTileServer(TypesyncModel):
             raise ValueError("'vector' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbProjectCompletenessCreateOnlyInput(TypesyncModel):
     """Represents COMPLETNESS project fields that are valid while creating a project"""
-
     zoomLevel: int
     tileServer: FbObjRasterTileServer
     tileServerB: FbObjRasterTileServer
@@ -715,10 +685,8 @@ class FbProjectCompletenessCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbTeam(TypesyncModel):
     """Represents a team to limit project visibility."""
-
     teamName: str
     teamToken: str
     isArchived: bool
@@ -731,11 +699,9 @@ class FbTeam(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbEnumInformationPageBlockType(enum.Enum):
     TEXT = "text"
     IMAGE = "image"
-
 
 class FbInformationPageBlock(TypesyncModel):
     blockNumber: int
@@ -755,7 +721,6 @@ class FbInformationPageBlock(TypesyncModel):
             raise ValueError("'image' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbInformationPage(TypesyncModel):
     pageNumber: int
     title: str
@@ -771,7 +736,6 @@ class FbInformationPage(TypesyncModel):
             raise ValueError("'blocks' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbScreenBlock(TypesyncModel):
     title: str
     description: str
@@ -784,7 +748,6 @@ class FbScreenBlock(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
-
 
 class FbScreen(TypesyncModel):
     hint: FbScreenBlock
@@ -799,16 +762,9 @@ class FbScreen(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbBaseTutorial(TypesyncModel):
-    exampleImage1: typing.Annotated[
-        str | TypesyncUndefined | None,
-        pydantic.Field(deprecated=True),
-    ] = UNDEFINED
-    exampleImage2: typing.Annotated[
-        str | TypesyncUndefined | None,
-        pydantic.Field(deprecated=True),
-    ] = UNDEFINED
+    exampleImage1: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
+    exampleImage2: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
     contributorCount: int
     informationPages: list[FbInformationPage] | TypesyncUndefined | None = UNDEFINED
     lookFor: str | TypesyncUndefined | None = UNDEFINED
@@ -839,7 +795,6 @@ class FbBaseTutorial(TypesyncModel):
             raise ValueError("'screens' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbBaseTutorialGroup(TypesyncModel):
     finishedCount: int
     groupId: int
@@ -856,7 +811,6 @@ class FbBaseTutorialGroup(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbCompareTutorial(TypesyncModel):
     projectType: typing.Literal[3]
     tileServer: FbObjRasterTileServer
@@ -871,7 +825,6 @@ class FbCompareTutorial(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbCompareTutorialTask(TypesyncModel):
     url: str
     urlB: str
@@ -883,7 +836,6 @@ class FbCompareTutorialTask(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
-
 
 class FbCompletenessTutorial(TypesyncModel):
     projectType: typing.Literal[4]
@@ -900,7 +852,6 @@ class FbCompletenessTutorial(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbCompletenessTutorialTask(TypesyncModel):
     url: str
     urlB: str
@@ -913,6 +864,46 @@ class FbCompletenessTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
+class FbConflationTutorial(TypesyncModel):
+    inputGeometries: typing.Annotated[str, pydantic.Field(deprecated=True)]
+    projectType: typing.Literal[8]
+    tileServer: FbObjRasterTileServer
+    zoomLevel: typing.Annotated[int, pydantic.Field(deprecated=True)]
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        super().__setattr__(name, value)
+
+class FbConflationTutorialTaskProperties(TypesyncModel):
+    id: int
+    screen: int
+    reference: int
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        super().__setattr__(name, value)
+
+class FbConflationTutorialTask(TypesyncModel):
+    taskId: str
+    geojson: typing.Any
+    properties: FbConflationTutorialTaskProperties
+    geometry: str
+
+    class Config:
+        use_enum_values = False
+        extra = "forbid"
+
+    @typing.override
+    def __setattr__(self, name: str, value: typing.Any) -> None:
+        super().__setattr__(name, value)
 
 class FbFindTutorial(TypesyncModel):
     projectType: typing.Literal[1]
@@ -927,7 +918,6 @@ class FbFindTutorial(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbFindTutorialTask(TypesyncModel):
     url: str
 
@@ -938,7 +928,6 @@ class FbFindTutorialTask(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
-
 
 class FbStreetTutorial(TypesyncModel):
     projectType: typing.Literal[7]
@@ -953,7 +942,6 @@ class FbStreetTutorial(TypesyncModel):
         if name == "customOptions" and value is None:
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
-
 
 class FbStreetTutorialTask(TypesyncModel):
     projectId: str
@@ -971,7 +959,6 @@ class FbStreetTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbTileMapServiceTutorialGroup(TypesyncModel):
     xMax: int
     xMin: int
@@ -985,7 +972,6 @@ class FbTileMapServiceTutorialGroup(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
-
 
 class FbTileMapServiceTutorialTask(TypesyncModel):
     geometry: str
@@ -1006,7 +992,6 @@ class FbTileMapServiceTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbValidateTutorial(TypesyncModel):
     inputGeometries: typing.Annotated[str, pydantic.Field(deprecated=True)]
     projectType: typing.Literal[2]
@@ -1024,7 +1009,6 @@ class FbValidateTutorial(TypesyncModel):
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbValidateTutorialTaskProperties(TypesyncModel):
     id: int
     screen: int
@@ -1037,7 +1021,6 @@ class FbValidateTutorialTaskProperties(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
-
 
 class FbValidateTutorialTask(TypesyncModel):
     taskId: str
@@ -1053,7 +1036,6 @@ class FbValidateTutorialTask(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbValidateImageTutorial(TypesyncModel):
     projectType: typing.Literal[10]
     customOptions: list[FbObjCustomOption] | TypesyncUndefined | None = UNDEFINED
@@ -1067,7 +1049,6 @@ class FbValidateImageTutorial(TypesyncModel):
         if name == "customOptions" and value is None:
             raise ValueError("'customOptions' field cannot be set to None")
         super().__setattr__(name, value)
-
 
 class FbValidateImageTutorialTask(TypesyncModel):
     groupId: int
@@ -1102,20 +1083,12 @@ class FbValidateImageTutorialTask(TypesyncModel):
             raise ValueError("'segmentation' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbUserReadonlyType(TypesyncModel):
     """Represents user fields that cannot be updated from backend"""
-
     created: datetime.datetime
     lastAppUse: datetime.datetime | TypesyncUndefined | None = UNDEFINED
-    userName: typing.Annotated[
-        str | TypesyncUndefined | None,
-        pydantic.Field(deprecated=True),
-    ] = UNDEFINED
-    userNameKey: typing.Annotated[
-        str | TypesyncUndefined | None,
-        pydantic.Field(deprecated=True),
-    ] = UNDEFINED
+    userName: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
+    userNameKey: typing.Annotated[str | TypesyncUndefined | None, pydantic.Field(deprecated=True)] = UNDEFINED
     username: str | TypesyncUndefined | None = UNDEFINED
     usernameKey: str | TypesyncUndefined | None = UNDEFINED
     accessibility: bool | TypesyncUndefined | None = UNDEFINED
@@ -1155,10 +1128,8 @@ class FbUserReadonlyType(TypesyncModel):
             raise ValueError("'projectContributionCount' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbUserUpdateInput(TypesyncModel):
     """Represents a user"""
-
     teamId: str | TypesyncUndefined | None = UNDEFINED
 
     class Config:
@@ -1171,10 +1142,8 @@ class FbUserUpdateInput(TypesyncModel):
             raise ValueError("'teamId' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbUserContribution(TypesyncModel):
     """Represents a user contribution"""
-
     endTime: datetime.datetime
     startTime: datetime.datetime
     timestamp: datetime.datetime
@@ -1187,15 +1156,12 @@ class FbUserContribution(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbEnumUserGroupMembershipAction(enum.Enum):
     JOIN = "join"
     LEAVE = "leave"
 
-
 class FbUserGroupReadOnlyType(TypesyncModel):
     """Represents a usergroup"""
-
     users: dict[str, typing.Any] | TypesyncUndefined | None = UNDEFINED
 
     class Config:
@@ -1208,10 +1174,8 @@ class FbUserGroupReadOnlyType(TypesyncModel):
             raise ValueError("'users' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbUserGroupCreateOnlyInput(TypesyncModel):
     """Represents a usergroup"""
-
     createdAt: int
     createdBy: str
 
@@ -1223,10 +1187,8 @@ class FbUserGroupCreateOnlyInput(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbUserGroupUpdateInput(TypesyncModel):
     """Represents a usergroup"""
-
     description: str
     name: str
     nameKey: typing.Annotated[str, pydantic.Field(deprecated=True)]
@@ -1245,10 +1207,8 @@ class FbUserGroupUpdateInput(TypesyncModel):
             raise ValueError("'archivedBy' field cannot be set to None")
         super().__setattr__(name, value)
 
-
 class FbUserGroupObsolete(TypesyncModel):
     """Represents a usergroup"""
-
     name: str
     description: str
 
@@ -1260,10 +1220,8 @@ class FbUserGroupObsolete(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbUserGroupMembership(TypesyncModel):
     """Represents a user contribution"""
-
     action: FbEnumUserGroupMembershipAction
     timestamp: int
     userGroupId: str
@@ -1277,10 +1235,8 @@ class FbUserGroupMembership(TypesyncModel):
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
 
-
 class FbBackendWait(TypesyncModel):
     """Represents if to wait for firebase."""
-
     ok: bool
     timestamp: datetime.datetime
 
@@ -1291,3 +1247,4 @@ class FbBackendWait(TypesyncModel):
     @typing.override
     def __setattr__(self, name: str, value: typing.Any) -> None:
         super().__setattr__(name, value)
+


### PR DESCRIPTION
Provides definitions for projects and tutorials of type Conflation, implemented with https://github.com/mapswipe/mapswipe-backend/pull/225

See also changes in:
* [MapSwipe web](https://github.com/mapswipe/mapswipe-web/pull/64)
* [Backend](https://github.com/mapswipe/mapswipe-backend/pull/225)
* [Assets](https://github.com/mapswipe/mapswipe-assets/pull/26)
* [Manager Dashboard](https://github.com/mapswipe/manager-dashboard/pull/72)